### PR TITLE
qualify boost::range_[const|mutable]_iterator

### DIFF
--- a/include/boost/range/has_range_iterator.hpp
+++ b/include/boost/range/has_range_iterator.hpp
@@ -37,9 +37,9 @@ namespace boost
             T,
             BOOST_DEDUCED_TYPENAME ::boost::enable_if<
                 BOOST_DEDUCED_TYPENAME mpl::eval_if<is_const<T>,
-                    has_type<range_const_iterator<
+                    has_type<boost::range_const_iterator<
                                 BOOST_DEDUCED_TYPENAME remove_const<T>::type> >,
-                    has_type<range_mutable_iterator<T> >
+                    has_type<boost::range_mutable_iterator<T> >
                 >::type
             >::type
         >
@@ -57,7 +57,7 @@ namespace boost
         struct has_range_const_iterator_impl<
             T,
             BOOST_DEDUCED_TYPENAME ::boost::enable_if<
-                has_type<range_const_iterator<T> >
+                has_type<boost::range_const_iterator<T> >
             >::type
         >
             : boost::mpl::true_


### PR DESCRIPTION
Dear Neil,

`boost::has_range_iterator`
currently “calls” `boost::range_detail::has_range_iterator_impl`, 
which in turn “calls” `range_mutable_iterator`.
Due to the namespace being in, this boils down to `boost::range_detail::range_mutable_iterator`
and not `boost::range_mutable_iterator`. 
I expected the latter, because otherwise specializing this function as described in http://www.boost.org/doc/libs/1_59_0/libs/range/doc/html/range/reference/extending/method_2.html has no effect.

Tobi
